### PR TITLE
chore: bump cargo-shear to 1.13.1

### DIFF
--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ _default:
 alias r := ready
 
 init:
-  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear dprint -y
+  cargo binstall watchexec-cli cargo-insta typos-cli cargo-shear@1.13.1 dprint -y
 
 ready:
   git diff --exit-code --quiet
@@ -24,7 +24,7 @@ watch *args='':
   watchexec --no-vcs-ignore {{args}}
 
 fmt:
-  cargo shear --fix
+  cargo shear --fix --check-test-targets
   cargo fmt --all
   dprint fmt
 


### PR DESCRIPTION
Bumps cargo-shear to 1.13.1 and runs cargo shear with `--check-test-targets`.