### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,19 +1,6 @@
 style_edition = "2024"
-
-# Make Rust more readable given most people have wide screens nowadays.
-# This is also the setting used by [rustc](https://github.com/rust-lang/rust/blob/master/rustfmt.toml)
 use_small_heuristics = "Max"
-
-# Use field initialize shorthand if possible
 use_field_init_shorthand = true
-
 reorder_modules = true
-
-# All unstable features that we wish for
-# unstable_features = true
-# Provide a cleaner impl order
-# reorder_impl_items = true
-# Provide a cleaner import sort order
-# group_imports = "StdExternalCrate"
-# Group "use" statements by crate
-# imports_granularity = "Crate"
+merge_derives = true
+remove_nested_parens = true


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
